### PR TITLE
Switch to node v20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -59,7 +59,7 @@ runs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 21
+        node-version: 20
 
     - name: Install dependencies
       working-directory: ${{github.action_path}}


### PR DESCRIPTION
## Summary

This version switches the action to use node v20 instead of node v21. This is due to the fact that node v21 is set to reach its EOL soon, whereas v20 has long term support.

Reference: https://endoflife.date/nodejs