### PR TITLE
Update README to show examples of ignored rules/paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Repositories in the MetaMask GitHub organization will pass the following secrets
 
 ## Features
 
-- **CodeQL Analysis**: Leverages [MetaMask/Appsec-CodeQL](https://github.com/MetaMask/codeql-action), a wrapper around GitHub's CodeQL engine](https://codeql.github.com/), to identify vulnerabilities in the codebase.
+- **CodeQL Analysis**: Leverages [MetaMask/Appsec-CodeQL](https://github.com/MetaMask/codeql-action), a wrapper around GitHub's [CodeQL engine](https://codeql.github.com/), to identify vulnerabilities in the codebase.
 
 ## Disclaimer
 


### PR DESCRIPTION
This PR primarily focuses on improving the README so that its clearer to development teams that `paths_ignored` and `rules_excluded` should be listed on new lines.

It also removes the future plans section which is noted at the top.