### PR TITLE
Make mixpanel and slack notifications optional

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -43,7 +43,7 @@ runs:
     # TODO check if we are blocking PR, e.g if we are on a PR and the scan failed, then fail the PR
     - name: Post to a Slack channel
       id: slack
-      if: ${{ env.CODEQL_SCAN_RESULT == 'failure' && inputs.slack_webhook != "" }}
+      if: ${{ env.CODEQL_SCAN_RESULT == 'failure' && inputs.slack_webhook != '' }}
       uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
       with:
         payload: |


### PR DESCRIPTION
PR from forks don't have required secrets and are failing, this PR makes it so that the logging steps are not ran if those secrets are missing