### PR TITLE
Fix syntax error in action example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ jobs:
         uses: MetaMask/Security-Code-Scanner@main
         with:
           repo: ${{ github.repository }}
-           paths_ignored: |
+          paths_ignored: |
             .storybook/
             '**/__snapshots__/'
             '**/*.snap'


### PR DESCRIPTION
This pull request fixes a syntax error that users of this action will experience when copying the action example. The extra space resulted in failures when attempting to use the action.