### PR TITLE
Update README example to update workflow triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ on:
   push:
     branches: [ 'main' ]
   pull_request:
-    branches: [ 'main' ]
   workflow_dispatch:
   
 jobs:


### PR DESCRIPTION
This pull request updates the example usage in the readme to include the manual dispatch trigger. This allows for the run to be triggered manually on repositories which are inactive, and may not have builds being pushed to trigger workflows. It also updates the configuration such that it runs on every pull request. 