### PR TITLE
Ensure tags are fetched in release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          # This is to guarantee that the most recent tag is fetched, which we
+          # need for updating the shorthand major version tag.
+          fetch-depth: 0
           ref: ${{ github.sha }}
       - name: Publish release
         uses: MetaMask/action-publish-release@v3


### PR DESCRIPTION
See MetaMask/action-checkout-and-setup#13 and [`action-npm-publish`](https://github.com/MetaMask/action-npm-publish/blob/4152be6add0844778d4a11b4dadcdfadcd83ba22/.github/workflows/publish-release.yml#L18-L20).