### PR TITLE
fix: Make slack_webhook an optional input

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -17,7 +17,7 @@ inputs:
     required: false
   slack_webhook:
     description: "Slack webhook for notifications"
-    required: true
+    required: false
 
 runs:
   using: "composite"


### PR DESCRIPTION
## Summary

The `slack_webhook` input can be provided such that scan failures are reported to a slack channel. This is not required for the code scanners operation, and therefor it should not be required as an input. 