### PR TITLE
fix: avoid validating pull request title on release branches

### DIFF
--- a/.github/workflows/validate-conventional-commits.yml
+++ b/.github/workflows/validate-conventional-commits.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   pr-title-linter:
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref , 'release/') }}
     steps:
       # this is a hash for amannn/action-semantic-pull-request@v5.4.0
       - uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f


### PR DESCRIPTION
## Summary

#35 is blocked due to the fact that our semantic commit validation is occurring on release branches. This pull request opts those branches out of this formatting check. 

