### PR TITLE
2. Monorepo codeql package

### DIFF
--- a/.github/workflows/reusable-codeql.yml
+++ b/.github/workflows/reusable-codeql.yml
@@ -1,0 +1,66 @@
+name: 'Reusable CodeQL Analysis'
+
+on:
+  workflow_call:
+    inputs:
+      languages:
+        description: 'JSON array of programming languages to scan (e.g., ["javascript", "python"])'
+        required: true
+        type: string
+      repo:
+        description: 'Repository that requested the scan'
+        required: true
+        type: string
+      paths_ignored:
+        description: 'Comma delimited paths to ignore during scan'
+        required: false
+        type: string
+        default: ''
+      rules_excluded:
+        description: 'Comma delimited IDs of rules to exclude'
+        required: false
+        type: string
+        default: ''
+    outputs:
+      sarif-id:
+        description: 'SARIF file identifier'
+        value: ${{ jobs.codeql-analysis.outputs.sarif-id }}
+
+jobs:
+  codeql-analysis:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ${{ fromJSON(inputs.languages) }}
+
+    outputs:
+      sarif-id: ${{ steps.upload.outputs.sarif-id }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.repo }}
+          path: ${{ inputs.repo }}
+
+      - name: Call Security Code Scanner CodeQL Action
+        id: codeql-scan
+        uses: ./packages/codeql-action@main
+        with:
+          repo: ${{ inputs.repo }}
+          language: ${{ matrix.language }}
+          paths_ignored: ${{ inputs.paths_ignored }}
+          rules_excluded: ${{ inputs.rules_excluded }}
+
+      - name: Upload SARIF with language suffix
+        id: upload
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ${{ steps.codeql-scan.outputs.sarif-output }}
+          category: codeql-${{ matrix.language }}

--- a/packages/codeql-action/.gitignore
+++ b/packages/codeql-action/.gitignore
@@ -1,0 +1,11 @@
+node_modules/
+package-lock.json
+.env
+pnpm-lock.yaml
+package-lock.json
+.DS_Store
+codeql-config-generated.yml
+github_output
+.env.test
+.yarn/cache
+.yarn/install-state.gz

--- a/packages/codeql-action/README.md
+++ b/packages/codeql-action/README.md
@@ -1,0 +1,233 @@
+# CodeQL Action
+
+Custom CodeQL analysis action with repository-specific configurations and custom query suites.
+
+## Overview
+
+This action provides flexible CodeQL scanning with:
+- **Automatic language detection** via GitHub API
+- **Repository-specific configurations** in `repo-configs/`
+- **Custom query suites** for specialized security analysis
+- **Per-language build settings** (version, distribution, build commands)
+
+## Architecture
+
+The action works as part of the security scanning workflow:
+
+1. **Language detector** creates scan matrix from detected languages
+2. **Config loader** reads repo-specific config from `repo-configs/<repo-name>.js`
+3. **Config generator** merges inputs with repo config and generates CodeQL config
+4. **CodeQL** performs analysis and uploads SARIF results
+
+## Inputs
+
+| Input | Required | Description |
+|-------|----------|-------------|
+| `repo` | ✅ | Repository name (format: `owner/repo`) |
+| `language` | ✅ | Language to scan (e.g., `javascript-typescript`, `java-kotlin`, `python`) |
+| `paths_ignored` | ❌ | Newline-delimited paths to ignore |
+| `rules_excluded` | ❌ | Newline-delimited CodeQL rule IDs to exclude |
+| `build_mode` | ❌ | Build mode: `none`, `autobuild`, or `manual` |
+| `build_command` | ❌ | Build command for `manual` build mode |
+| `version` | ❌ | Language/runtime version (e.g., `21` for Java, `3.10` for Python) |
+| `distribution` | ❌ | Distribution (e.g., `temurin`, `zulu` for Java) |
+
+## Usage
+
+### Via Reusable Workflow (Recommended)
+
+```yaml
+name: Security Scan
+on: [push, pull_request]
+
+jobs:
+  security:
+    uses: metamask/security-codescanner-monorepo/.github/workflows/security-scan.yml@main
+    with:
+      repo: ${{ github.repository }}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+```
+
+### Direct Action Usage
+
+```yaml
+- name: Run CodeQL Analysis
+  uses: metamask/security-codescanner-monorepo/packages/codeql-action@main
+  with:
+    repo: ${{ github.repository }}
+    language: javascript-typescript
+    paths_ignored: |
+      test/
+      docs/
+    rules_excluded: |
+      js/log-injection
+```
+
+## Repository Configuration
+
+### File-Based Config
+
+Create `repo-configs/<repo-name>.js`:
+
+```javascript
+const config = {
+  // Paths to ignore during scan
+  pathsIgnored: ['test', 'vendor', 'node_modules'],
+
+  // Rule IDs to exclude
+  rulesExcluded: ['js/log-injection', 'js/unsafe-dynamic-method-access'],
+
+  // Per-language configuration
+  languages_config: [
+    {
+      language: 'java-kotlin',
+      build_mode: 'manual',
+      build_command: './gradlew :coordinator:app:build',
+      version: '21',
+      distribution: 'temurin'
+    },
+    {
+      language: 'javascript-typescript',
+      // Uses default config (no build needed)
+    },
+    {
+      language: 'cpp',
+      ignore: true  // Skip C++ scanning
+    }
+  ],
+
+  // CodeQL query suites
+  queries: [
+    { name: 'Base security queries', uses: './query-suites/base.qls' },
+    { name: 'Custom queries', uses: './custom-queries/query-suites/custom-queries.qls' }
+  ]
+};
+
+export default config;
+```
+
+### Configuration Priority
+
+1. **Workflow input** (highest priority) - overrides everything
+2. **Repo config file** - `repo-configs/<repo-name>.js`
+3. **Default config** - `repo-configs/default.js`
+
+### Default Configurations
+
+The action includes sensible defaults for common languages:
+
+```javascript
+const DEFAULT_CONFIGS = {
+  'javascript': { language: 'javascript-typescript' },
+  'typescript': { language: 'javascript-typescript' },
+  'python': { language: 'python' },
+  'go': { language: 'go' },
+  'java': {
+    language: 'java-kotlin',
+    build_mode: 'manual',
+    build_command: './mvnw compile'
+  },
+  'cpp': { language: 'cpp' },
+  'csharp': { language: 'csharp' },
+  'ruby': { language: 'ruby' }
+};
+```
+
+## Supported Languages
+
+| GitHub Language | CodeQL Language | Build Required |
+|-----------------|-----------------|----------------|
+| JavaScript | `javascript-typescript` | No |
+| TypeScript | `javascript-typescript` | No |
+| Python | `python` | No |
+| Java | `java-kotlin` | Yes (defaults to `./mvnw compile`) |
+| Kotlin | `java-kotlin` | Yes |
+| Go | `go` | No |
+| C/C++ | `cpp` | Yes |
+| C# | `csharp` | Yes |
+| Ruby | `ruby` | No |
+
+## Build Modes
+
+### `none`
+No build needed (interpreted languages like JavaScript, Python)
+
+### `autobuild`
+CodeQL automatically detects and runs build (works for simple projects)
+
+### `manual`
+Specify exact build command:
+```javascript
+{
+  language: 'java-kotlin',
+  build_mode: 'manual',
+  build_command: './gradlew clean build'
+}
+```
+
+## Custom Query Suites
+
+Query suites define which CodeQL queries to run:
+
+**Built-in suites:**
+- `./query-suites/base.qls` - Standard security queries
+- `./query-suites/linea-monorepo.qls` - Project-specific queries
+
+**Custom queries:**
+- Checked out from `metamask/CodeQL-Queries` repository
+- Available at `./custom-queries/query-suites/custom-queries.qls`
+
+## Troubleshooting
+
+### Config not loading
+- Filename must match repo: `owner/repo` → `repo.js`
+- Must use ESM: `export default config`
+- Check logs: `[config-loader] Loading config for repository: ...`
+
+### Build failures
+- Verify `build_command` works locally
+- Check Java version matches `version` input
+- Review build step logs in Actions
+
+### Language not detected
+- Check GitHub language stats (repo → Insights → Languages)
+- Add language manually via `languages_config` in repo config
+- Verify language mapping in `language-detector/src/job-configurator.js`
+
+### SARIF upload errors
+- Ensure workflow has `security-events: write` permission
+- Check SARIF file is generated in `${{ steps.codeql-analysis.outputs.sarif-output }}`
+- Review CodeQL analysis logs
+
+## Security
+
+See [SECURITY.md](../../SECURITY.md) for:
+- Threat model and security boundaries
+- Input validation approach
+- Token permissions model
+
+## Development
+
+### Testing Config Changes
+
+```bash
+# Run config generator locally
+cd packages/codeql-action
+REPO=owner/repo LANGUAGE=javascript node scripts/generate-config.js
+
+# Validate generated config
+cat codeql-config-generated.yml
+```
+
+### Adding New Language Support
+
+1. Add to `LANGUAGE_MAPPING` in `language-detector/src/job-configurator.js`
+2. Add default config in `language-detector/src/job-configurator.js` → `DEFAULT_CONFIGS`
+3. Update this README's supported languages table
+
+## License
+
+ISC

--- a/packages/codeql-action/__tests__/config-loader.test.js
+++ b/packages/codeql-action/__tests__/config-loader.test.js
@@ -1,0 +1,96 @@
+import { loadRepoConfig, getDefaultConfig } from '../src/config-loader.js';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('config-loader', () => {
+  describe('getDefaultConfig', () => {
+    test('returns default configuration', () => {
+      const config = getDefaultConfig();
+
+      expect(config).toHaveProperty('pathsIgnored');
+      expect(config).toHaveProperty('rulesExcluded');
+      expect(config).toHaveProperty('languages_config');
+      expect(config).toHaveProperty('queries');
+
+      expect(Array.isArray(config.pathsIgnored)).toBe(true);
+      expect(Array.isArray(config.rulesExcluded)).toBe(true);
+      expect(Array.isArray(config.queries)).toBe(true);
+    });
+
+    test('includes expected default values', () => {
+      const config = getDefaultConfig();
+
+      expect(config.pathsIgnored).toContain('test');
+      expect(config.rulesExcluded).toContain('js/log-injection');
+      expect(config.queries.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('loadRepoConfig', () => {
+    test('loads existing repo config', async () => {
+      // Test with the existing lll.js config
+      const configDir = path.join(__dirname, '..', 'repo-configs');
+      const config = await loadRepoConfig('owner/lll', configDir);
+
+      expect(config).toBeDefined();
+      expect(config).toHaveProperty('pathsIgnored');
+      expect(config).toHaveProperty('queries');
+    });
+
+    test('falls back to default.js when repo config not found', async () => {
+      const configDir = path.join(__dirname, '..', 'repo-configs');
+      const config = await loadRepoConfig('owner/nonexistent-repo', configDir);
+
+      // Should return default config
+      expect(config).toBeDefined();
+      expect(config.pathsIgnored).toContain('test');
+    });
+
+    test('returns default config when config directory does not exist', async () => {
+      const config = await loadRepoConfig('owner/repo', '/nonexistent/path');
+
+      expect(config).toBeDefined();
+      expect(config).toHaveProperty('pathsIgnored');
+      expect(config).toHaveProperty('rulesExcluded');
+    });
+
+    test('handles malformed config gracefully', async () => {
+      // Create temp directory with config that throws an error
+      const tempDir = path.join(__dirname, 'temp-configs');
+      fs.mkdirSync(tempDir, { recursive: true });
+
+      try {
+        // Write a config that will cause an error when evaluated (but is valid JS)
+        const badConfigPath = path.join(tempDir, 'errorconfig.js');
+        fs.writeFileSync(badConfigPath, 'throw new Error("Config error"); export default {};');
+
+        const config = await loadRepoConfig('owner/errorconfig', tempDir);
+
+        // Should fall back to default config
+        expect(config).toBeDefined();
+        expect(config.pathsIgnored).toContain('test');
+      } finally {
+        // Cleanup - ensure it runs even if test fails
+        try {
+          fs.rmSync(tempDir, { recursive: true, force: true });
+        } catch (e) {
+          // Ignore cleanup errors
+        }
+      }
+    });
+
+    test('extracts repo name from owner/repo format', async () => {
+      const configDir = path.join(__dirname, '..', 'repo-configs');
+
+      // Should look for lll.js (not owner/lll.js)
+      const config = await loadRepoConfig('metamask/lll', configDir);
+
+      expect(config).toBeDefined();
+      // If lll.js exists, it should load it; otherwise default
+    });
+  });
+});

--- a/packages/codeql-action/__tests__/validation.test.js
+++ b/packages/codeql-action/__tests__/validation.test.js
@@ -1,0 +1,167 @@
+import {
+  validateRequiredInputs,
+  sanitizePath,
+  sanitizeRuleId,
+  escapeOutput
+} from '../src/validation.js';
+
+describe('validation', () => {
+  describe('validateRequiredInputs', () => {
+    test('passes when repo and language are provided', () => {
+      const inputs = { repo: 'owner/repo', language: 'javascript' };
+      expect(() => validateRequiredInputs(inputs)).not.toThrow();
+    });
+
+    test('throws when repo is missing', () => {
+      const inputs = { language: 'javascript' };
+      expect(() => validateRequiredInputs(inputs)).toThrow('Missing required inputs');
+    });
+
+    test('throws when language is missing', () => {
+      const inputs = { repo: 'owner/repo' };
+      expect(() => validateRequiredInputs(inputs)).toThrow('Missing required inputs');
+    });
+
+    test('throws when both are missing', () => {
+      const inputs = {};
+      expect(() => validateRequiredInputs(inputs)).toThrow('Missing required inputs');
+    });
+
+    test('throws when repo is empty string', () => {
+      const inputs = { repo: '', language: 'javascript' };
+      expect(() => validateRequiredInputs(inputs)).toThrow('Missing required inputs');
+    });
+
+    test('throws when language is empty string', () => {
+      const inputs = { repo: 'owner/repo', language: '' };
+      expect(() => validateRequiredInputs(inputs)).toThrow('Missing required inputs');
+    });
+  });
+
+  describe('sanitizePath', () => {
+    test('removes semicolons', () => {
+      expect(sanitizePath('test;rm -rf /')).toBe('testrm -rf /');
+    });
+
+    test('removes pipes', () => {
+      expect(sanitizePath('test|cat /etc/passwd')).toBe('testcat /etc/passwd');
+    });
+
+    test('removes backticks', () => {
+      expect(sanitizePath('test`whoami`')).toBe('testwhoami');
+    });
+
+    test('removes dollar signs', () => {
+      expect(sanitizePath('test$(whoami)')).toBe('testwhoami');
+    });
+
+    test('removes ampersands', () => {
+      expect(sanitizePath('test&background')).toBe('testbackground');
+    });
+
+    test('removes parentheses', () => {
+      expect(sanitizePath('test(subshell)')).toBe('testsubshell');
+    });
+
+    test('removes braces', () => {
+      expect(sanitizePath('test{1,2,3}')).toBe('test1,2,3');
+    });
+
+    test('removes brackets', () => {
+      expect(sanitizePath('test[0-9]')).toBe('test0-9');
+    });
+
+    test('removes angle brackets', () => {
+      expect(sanitizePath('test<input>output')).toBe('testinputoutput');
+    });
+
+    test('preserves valid path characters', () => {
+      expect(sanitizePath('src/components/Button.tsx')).toBe('src/components/Button.tsx');
+      expect(sanitizePath('test-utils/helpers_v2.js')).toBe('test-utils/helpers_v2.js');
+      expect(sanitizePath('./node_modules/@types')).toBe('./node_modules/@types');
+    });
+
+    test('handles multiple dangerous characters', () => {
+      expect(sanitizePath('test;$(rm -rf /)|cat&')).toBe('testrm -rf /cat');
+    });
+  });
+
+  describe('sanitizeRuleId', () => {
+    test('preserves valid rule IDs', () => {
+      expect(sanitizeRuleId('js/log-injection')).toBe('js/log-injection');
+      expect(sanitizeRuleId('py/sql-injection')).toBe('py/sql-injection');
+      expect(sanitizeRuleId('java/unsafe-deserialization')).toBe('java/unsafe-deserialization');
+    });
+
+    test('preserves underscores', () => {
+      expect(sanitizeRuleId('js/unsafe_dynamic_access')).toBe('js/unsafe_dynamic_access');
+    });
+
+    test('removes special characters', () => {
+      expect(sanitizeRuleId('js/rule;injection')).toBe('js/ruleinjection');
+      expect(sanitizeRuleId('py/rule|pipe')).toBe('py/rulepipe');
+      expect(sanitizeRuleId('java/rule@special')).toBe('java/rulespecial');
+    });
+
+    test('removes spaces', () => {
+      expect(sanitizeRuleId('js/log injection')).toBe('js/loginjection');
+    });
+
+    test('removes shell metacharacters', () => {
+      expect(sanitizeRuleId('js/rule$(whoami)')).toBe('js/rulewhoami');
+      expect(sanitizeRuleId('js/rule`cmd`')).toBe('js/rulecmd');
+    });
+
+    test('handles empty string', () => {
+      expect(sanitizeRuleId('')).toBe('');
+    });
+  });
+
+  describe('escapeOutput', () => {
+    test('escapes percent signs', () => {
+      expect(escapeOutput('test%value')).toBe('test%25value');
+      expect(escapeOutput('100%')).toBe('100%25');
+    });
+
+    test('escapes carriage returns', () => {
+      expect(escapeOutput('test\rvalue')).toBe('test%0Dvalue');
+    });
+
+    test('escapes newlines', () => {
+      expect(escapeOutput('test\nvalue')).toBe('test%0Avalue');
+    });
+
+    test('escapes multiple special characters', () => {
+      expect(escapeOutput('line1\nline2\rvalue%')).toBe('line1%0Aline2%0Dvalue%25');
+    });
+
+    test('escapes percent before newlines (order matters)', () => {
+      // Percent must be escaped first, otherwise %0A becomes %250A
+      const result = escapeOutput('%\n');
+      expect(result).toBe('%25%0A');
+      expect(result).not.toBe('%250A');
+    });
+
+    test('handles empty values', () => {
+      expect(escapeOutput('')).toBe('');
+      expect(escapeOutput(null)).toBe('');
+      expect(escapeOutput(undefined)).toBe('');
+    });
+
+    test('converts non-string values to string', () => {
+      expect(escapeOutput(123)).toBe('123');
+      expect(escapeOutput(true)).toBe('true');
+    });
+
+    test('handles values without special characters', () => {
+      expect(escapeOutput('normal-value')).toBe('normal-value');
+      expect(escapeOutput('test_123')).toBe('test_123');
+    });
+
+    test('prevents workflow variable injection', () => {
+      // Example of potential injection attempt
+      const malicious = 'value\nmalicious_var=injected';
+      expect(escapeOutput(malicious)).toBe('value%0Amalicious_var=injected');
+    });
+  });
+});

--- a/packages/codeql-action/action.yaml
+++ b/packages/codeql-action/action.yaml
@@ -1,0 +1,130 @@
+name: 'Security Code Scanner - CodeQL'
+description: 'Run custom CodeQL analysis'
+inputs:
+  repo:
+    description: 'Repository that requested the scan'
+    required: true
+  language:
+    description: 'Programming language to analyze'
+    required: true
+  paths_ignored:
+    description: 'Comma delimited paths to ignore during scan'
+    required: false
+  rules_excluded:
+    description: 'Comma delimited IDs of rules to exclude'
+    required: false
+  build_mode:
+    description: 'Build mode for the language'
+    required: false
+  build_command:
+    description: 'Build command for the language'
+    required: false
+    default: null
+  version:
+    description: 'Language/runtime version to use (e.g., 17, 21 for Java; 3.9, 3.10 for Python; 16, 18 for Node.js)'
+    required: false
+  distribution:
+    description: 'Language/runtime distribution to use (e.g., temurin, zulu, corretto for Java; pyenv for Python)'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Debug CodeQL Action Inputs
+      run: |
+        echo "=================== CODEQL ACTION INPUT DEBUG ==================="
+        echo "Repository: ${{ inputs.repo }}"
+        echo "Language: ${{ inputs.language }}"
+        echo "Build mode: ${{ inputs.build_mode }}"
+        echo "Build command: ${{ inputs.build_command }}"
+        echo "Version: ${{ inputs.version }}"
+        echo "Distribution: ${{ inputs.distribution }}"
+        echo "Paths ignored: ${{ inputs.paths_ignored }}"
+        echo "Rules excluded: ${{ inputs.rules_excluded }}"
+        echo "=================================================================="
+      shell: bash
+
+
+    - name: Enable Corepack
+      run: corepack enable
+      shell: bash
+
+    - name: Copy Query Suites to Workspace Root
+      run: |
+        echo "Copying query suites to workspace root for CodeQL..."
+        cp -r ${{ github.action_path }}/query-suites ${{ github.workspace }}/
+      shell: bash
+
+    - name: Generate Config
+      id: generate-config
+      run: |
+        # Install dependencies and run script from monorepo directory
+        cd ${{ github.workspace }}/${MONOREPO_PATH:-.security-scanner}
+        yarn install --immutable
+        cd packages/codeql-action
+        node scripts/generate-config.js
+      shell: bash
+      env:
+        REPO: ${{inputs.repo}}
+        LANGUAGE: ${{ inputs.language }}
+        PATHS_IGNORED: ${{ inputs.paths_ignored}}
+        RULES_EXCLUDED: ${{ inputs.rules_excluded}}
+
+    - name: Debug Config Generation Outputs
+      run: |
+        echo "================= CONFIG GENERATION OUTPUTS ================="
+        echo "Languages: ${{ steps.generate-config.outputs.languages }}"
+        echo "Build mode: ${{ steps.generate-config.outputs.build_mode }}"
+        echo "Build command: ${{ steps.generate-config.outputs.build_command }}"
+        echo "Version: ${{ steps.generate-config.outputs.version }}"
+        echo "Distribution: ${{ steps.generate-config.outputs.distribution }}"
+        echo "=============================================================="
+        echo ""
+        echo "================= GENERATED CODEQL CONFIG FILE ================="
+        cat ${{ github.workspace }}/codeql-config-generated.yml
+        echo "=================================================================="
+      shell: bash
+
+    - name: Checkout Custom Query Repository
+      id: checkout-custom-query
+      uses: actions/checkout@v4
+      with:
+        repository: metamask/CodeQL-Queries
+        ref: main
+        path: ${{ github.workspace }}/custom-queries
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        config-file: ${{ github.workspace }}/codeql-config-generated.yml
+        languages: ${{ inputs.language }}
+        source-root: ${{ inputs.repo }}
+
+
+    - name: Set up JDK for Java/Kotlin
+      if: ${{ (inputs.language == 'java-kotlin' || inputs.language == 'java') && steps.generate-config.outputs.version != '' }}
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ steps.generate-config.outputs.version }}
+        distribution: ${{ steps.generate-config.outputs.distribution || 'temurin' }}
+
+    - name: Build code
+      if: ${{ steps.generate-config.outputs.build_mode == 'manual' && steps.generate-config.outputs.build_command != '' }}
+      run: |
+        echo "Building code with command: ${{ steps.generate-config.outputs.build_command }}"
+        cd ${{ github.workspace }}/${{ inputs.repo }}
+        ${{ steps.generate-config.outputs.build_command }}
+      shell: bash
+
+    - name: Run CodeQL Analysis
+      id: codeql-analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        upload: false
+        checkout_path: ${{ github.workspace }}/${{ inputs.repo }}
+
+    - name: Upload SARIF file
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: ${{ steps.codeql-analysis.outputs.sarif-output }}
+        category: codeql-${{ inputs.language }}

--- a/packages/codeql-action/config/codeql-template.yml
+++ b/packages/codeql-action/config/codeql-template.yml
@@ -1,0 +1,20 @@
+name: "Security Code Scanner CodeQL Config"
+
+paths-ignore:
+<% pathsIgnored.forEach(function(path) { -%>
+  - "<%- path %>"
+<% }); -%>
+
+queries:
+<% queries.forEach(function(query) { -%>
+  - name: <%- query.name %>
+    uses: <%- query.uses %>
+<% }); -%>
+
+<% if (rulesExcluded?.length > 0) { -%>
+query-filters:
+  <% rulesExcluded.forEach(function(rule) { -%>
+- exclude:
+      id: <%- rule %>
+  <% }); -%>
+<% } %>

--- a/packages/codeql-action/jest.config.js
+++ b/packages/codeql-action/jest.config.js
@@ -1,0 +1,14 @@
+export default {
+  testEnvironment: 'node',
+  transform: {},
+  preset: null,
+  testMatch: [
+    '**/__tests__/**/*.test.js'
+  ],
+  collectCoverageFrom: [
+    'src/**/*.js',
+    'scripts/**/*.js',
+    '!**/*.test.js'
+  ],
+  verbose: true
+};

--- a/packages/codeql-action/package.json
+++ b/packages/codeql-action/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@metamask/codeql-action",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Custom CodeQL analysis action",
+  "type": "module",
+  "keywords": [],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:MetaMask/security-codescanner-monorepo.git"
+  },
+  "license": "ISC",
+  "author": "witmicko",
+  "main": "index.js",
+  "scripts": {
+    "lint": "prettier '**/*.json' '**/*.md' '**/*.yml' '**/*.js' --check --ignore-path .gitignore --no-error-on-unmatched-pattern",
+    "lint:fix": "prettier '**/*.json' '**/*.md' '**/*.yml' '**/*.js' --write --ignore-path .gitignore --no-error-on-unmatched-pattern",
+    "test": "NODE_OPTIONS=--experimental-vm-modules yarn exec jest",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules yarn exec jest --watch",
+    "test:coverage": "NODE_OPTIONS=--experimental-vm-modules yarn exec jest --coverage"
+  },
+  "dependencies": {
+    "ejs": "^3.1.10"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.8",
+    "jest": "^29.7.0"
+  }
+}

--- a/packages/codeql-action/query-suites/base.qls
+++ b/packages/codeql-action/query-suites/base.qls
@@ -1,0 +1,2 @@
+- import: codeql-suites/javascript-security-extended.qls
+  from: codeql/javascript-queries

--- a/packages/codeql-action/query-suites/extension.qls
+++ b/packages/codeql-action/query-suites/extension.qls
@@ -1,0 +1,6 @@
+- queries: '.'
+  from: codeql/javascript-queries
+- include:
+    kind: problem
+
+- qlpack: appsec-queries/all

--- a/packages/codeql-action/query-suites/linea-monorepo.qls
+++ b/packages/codeql-action/query-suites/linea-monorepo.qls
@@ -1,0 +1,22 @@
+- queries: '.'
+  from: codeql/javascript-queries
+  include:
+    kind: problem
+
+- queries: '.'
+  from: codeql/go-queries
+  include:
+    kind: problem
+
+- queries: '.'
+  from: codeql/java-queries
+  include:
+    kind: problem
+
+- queries: '.'
+  from: codeql/actions-queries
+  include:
+    kind: problem
+
+
+

--- a/packages/codeql-action/query-suites/mobile.qls
+++ b/packages/codeql-action/query-suites/mobile.qls
@@ -1,0 +1,6 @@
+- queries: '.'
+  from: codeql/javascript-queries
+- include:
+    kind: problem
+
+- qlpack: appsec-queries/all

--- a/packages/codeql-action/repo-configs/default.js
+++ b/packages/codeql-action/repo-configs/default.js
@@ -1,0 +1,16 @@
+const config = {
+  pathsIgnored: ['test'],
+  rulesExcluded: ['js/log-injection'],
+  queries: [
+    {
+      name: 'Security-extended queries for JavaScript',
+      uses: './query-suites/base.qls',
+    },
+    {
+      name: 'Security Code Scanner Custom Queries',
+      uses: './custom-queries/query-suites/custom-queries.qls',
+    },
+  ],
+};
+
+export default config;

--- a/packages/codeql-action/repo-configs/lll.js
+++ b/packages/codeql-action/repo-configs/lll.js
@@ -1,0 +1,29 @@
+const config = {
+  pathsIgnored: ['test'],
+  rulesExcluded: ['js/log-injection'],
+  languages_config: [
+    {
+      "language": "java-kotlin",
+      "build_mode": "manual",
+      "build_command": "./gradlew :coordinator:app:build",
+      "version": "21",
+      "distribution": "temurin"
+    },
+    {
+      "language": "cpp",
+      "ignore": true
+    }
+  ],
+  queries: [
+    {
+      name: 'queries for linea',
+      uses: './query-suites/linea-monorepo.qls',
+    },
+    {
+      name: 'Security Code Scanner Custom Queries',
+      uses: './custom-queries/query-suites/custom-queries.qls',
+    },
+  ],
+};
+
+export default config;

--- a/packages/codeql-action/scripts/generate-config.js
+++ b/packages/codeql-action/scripts/generate-config.js
@@ -1,0 +1,102 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+import ejs from 'ejs';
+import { loadRepoConfig } from '../src/config-loader.js';
+import { validateRequiredInputs, sanitizePath, sanitizeRuleId, escapeOutput } from '../src/validation.js';
+
+// ESM equivalent of __dirname
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const outputFile = process.env.GITHUB_OUTPUT;
+const template = fs.readFileSync('config/codeql-template.yml', 'utf8');
+
+const { REPO, LANGUAGE, BUILD_MODE, BUILD_COMMAND, VERSION, DISTRIBUTION, PATHS_IGNORED, RULES_EXCLUDED } = process.env;
+
+const inputs = {
+  repo: REPO,
+  language: LANGUAGE,
+  buildMode: BUILD_MODE,
+  buildCommand: BUILD_COMMAND,
+  version: VERSION,
+  distribution: DISTRIBUTION,
+  pathsIgnored: PATHS_IGNORED
+    ? PATHS_IGNORED.split('\n').filter((line) => line.trim() !== '').map(sanitizePath)
+    : [],
+  rulesExcluded: RULES_EXCLUDED
+    ? RULES_EXCLUDED.split('\n').filter((line) => line.trim() !== '').map(sanitizeRuleId)
+    : [],
+};
+
+// Validate required inputs
+validateRequiredInputs(inputs);
+
+const applyLanguageConfigFallbacks = (inputs, config) => {
+  // If no language is specified, return inputs as-is
+  if (!inputs.language) {
+    return inputs;
+  }
+
+  // Find matching language config from languages_config array
+  const languageConfig = config.languages_config?.find(
+    langConfig => langConfig.language === inputs.language
+  );
+
+  if (!languageConfig) {
+    return inputs;
+  }
+
+  // Note: Ignore checking is now handled by language-detector during matrix creation
+  // Languages marked as ignored won't appear in the matrix, so we don't need to check here
+
+  // Apply fallbacks for missing inputs
+  const inputsWithFallbacks = { ...inputs };
+
+  if (!inputsWithFallbacks.buildMode && languageConfig.build_mode) {
+    inputsWithFallbacks.buildMode = languageConfig.build_mode;
+  }
+
+  if (!inputsWithFallbacks.buildCommand && languageConfig.build_command) {
+    inputsWithFallbacks.buildCommand = languageConfig.build_command;
+  }
+
+  if (!inputsWithFallbacks.version && languageConfig.version) {
+    inputsWithFallbacks.version = languageConfig.version;
+  }
+
+  if (!inputsWithFallbacks.distribution && languageConfig.distribution) {
+    inputsWithFallbacks.distribution = languageConfig.distribution;
+  }
+
+  return inputsWithFallbacks;
+};
+
+// Main execution - use top-level await (Node.js 14.8+)
+const config = await loadRepoConfig(inputs.repo, path.join(__dirname, '..', 'repo-configs'));
+
+// Apply language-specific config fallbacks
+const finalInputs = applyLanguageConfigFallbacks(inputs, config);
+
+// set languages output (safely escaped)
+fs.appendFileSync(outputFile, `languages=${escapeOutput(config.languages)}\n`);
+
+// set resolved values (inputs + fallbacks) as outputs for use in subsequent action steps (safely escaped)
+fs.appendFileSync(outputFile, `build_mode=${escapeOutput(finalInputs.buildMode || '')}\n`);
+fs.appendFileSync(outputFile, `build_command=${escapeOutput(finalInputs.buildCommand || '')}\n`);
+fs.appendFileSync(outputFile, `version=${escapeOutput(finalInputs.version || '')}\n`);
+fs.appendFileSync(outputFile, `distribution=${escapeOutput(finalInputs.distribution || '')}\n`);
+
+const output = ejs.render(template, {
+  pathsIgnored: [...config.pathsIgnored, ...finalInputs.pathsIgnored],
+  rulesExcluded: [...config.rulesExcluded, ...finalInputs.rulesExcluded],
+  queries: config.queries,
+});
+
+// Write to workspace root (or current directory if GITHUB_WORKSPACE not set)
+const outputPath = process.env.GITHUB_WORKSPACE
+  ? path.join(process.env.GITHUB_WORKSPACE, 'codeql-config-generated.yml')
+  : 'codeql-config-generated.yml';
+
+fs.writeFileSync(outputPath, output);

--- a/packages/codeql-action/src/config-loader.js
+++ b/packages/codeql-action/src/config-loader.js
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { dirname } from 'path';
+
+// ESM equivalent of __dirname
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * Loads repository-specific configuration
+ * @param {string} repo - Repository name in format 'owner/repo'
+ * @param {string} configDir - Directory containing repo configs (optional, defaults to '../repo-configs')
+ * @returns {Promise<Object>} Configuration object with pathsIgnored, rulesExcluded, languages_config, queries
+ */
+export async function loadRepoConfig(repo, configDir = null) {
+  try {
+    const repoName = repo.split('/')[1];
+
+    // Determine config directory
+    const baseDir = configDir || path.join(__dirname, '..', 'repo-configs');
+    const repoConfigPath = path.join(baseDir, `${repoName}.js`);
+
+    if (!fs.existsSync(repoConfigPath)) {
+      // Try default config
+      const defaultConfigPath = path.join(baseDir, 'default.js');
+
+      if (!fs.existsSync(defaultConfigPath)) {
+        return getDefaultConfig();
+      }
+
+      const defaultModule = await import(`file://${defaultConfigPath}`);
+      return defaultModule.default;
+    }
+
+    const configModule = await import(`file://${repoConfigPath}`);
+    return configModule.default;
+
+  } catch (error) {
+    console.error(`Error loading config for "${repo}": ${error.message}`);
+    console.error('Falling back to default configuration');
+    return getDefaultConfig();
+  }
+}
+
+/**
+ * Returns a basic default configuration when no config file is found
+ * @returns {Object} Default configuration
+ */
+export function getDefaultConfig() {
+  return {
+    pathsIgnored: ['test'],
+    rulesExcluded: ['js/log-injection'],
+    languages_config: [],
+    queries: [
+      {
+        name: 'Security-extended queries for JavaScript',
+        uses: './query-suites/base.qls',
+      },
+      {
+        name: 'Security Code Scanner Custom Queries',
+        uses: './custom-queries/query-suites/custom-queries.qls',
+      },
+    ],
+  };
+}

--- a/packages/codeql-action/src/validation.js
+++ b/packages/codeql-action/src/validation.js
@@ -1,0 +1,45 @@
+/**
+ * Input validation and sanitization utilities
+ */
+
+/**
+ * Validates required inputs
+ * @param {Object} inputs - Input object
+ * @throws {Error} If required fields are missing
+ */
+export function validateRequiredInputs(inputs) {
+  if (!inputs.repo || !inputs.language) {
+    throw new Error('Missing required inputs: REPO and LANGUAGE are required');
+  }
+}
+
+/**
+ * Sanitize path strings - remove shell metacharacters (good hygiene, prevents accidental issues)
+ * @param {string} pathStr - Path string to sanitize
+ * @returns {string} Sanitized path
+ */
+export function sanitizePath(pathStr) {
+  return pathStr.replace(/[;&|`$(){}[\]<>]/g, '');
+}
+
+/**
+ * Sanitize rule IDs - allow only alphanumeric, hyphens, slashes, and underscores
+ * @param {string} ruleId - Rule ID to sanitize
+ * @returns {string} Sanitized rule ID
+ */
+export function sanitizeRuleId(ruleId) {
+  return ruleId.replace(/[^a-zA-Z0-9\-/_]/g, '');
+}
+
+/**
+ * Escape output for GITHUB_OUTPUT - prevent workflow variable injection
+ * @param {*} value - Value to escape
+ * @returns {string} Escaped value
+ */
+export function escapeOutput(value) {
+  if (!value) return '';
+  return String(value)
+    .replace(/%/g, '%25')   // % must be first
+    .replace(/\r/g, '%0D')  // carriage return
+    .replace(/\n/g, '%0A'); // newline
+}


### PR DESCRIPTION
Migrated codeql-action

changes:
- improved config handling to support multi languages
- added tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrates to a monorepo with a reusable CodeQL workflow and a new CodeQL action supporting per-repo/per-language config, query suites, and tests.
> 
> - **Workflows**
>   - **Reusable CodeQL**: Adds `/.github/workflows/reusable-codeql.yml` with matrixed language scanning, inputs (`languages`, `repo`, etc.), and SARIF upload.
> - **Packages**
>   - **CodeQL Action**: New `packages/codeql-action/` with `action.yaml`, config generator (`scripts/generate-config.js`), validation utilities (`src/validation.js`), repo config loader (`src/config-loader.js`), EJS config template, query suites, and repo-specific configs (`repo-configs/default.js`, `repo-configs/lll.js`).
>   - **Tests**: Adds Jest config and tests for config loading and input validation.
> - **Repo Structure & Tooling**
>   - Convert to monorepo: updates root `package.json` (workspaces, scripts), adds shared configs/scripts (`shared/configs/*`, `shared/scripts/*`).
>   - Housekeeping: update `.gitignore`, add `.prettierignore`, refactor Prettier config to `shared/configs/prettier.config.js` with `.prettierrc.js` importing it; minor `.yarnrc.yml` tweak.
> - **Docs**
>   - Overhaul `README.md` with architecture, usage, config schema, and development instructions.
> - **Removals**
>   - Remove legacy composite `action.yaml` and scripts `scripts/check-ghas.js`, `scripts/log-to-mixpanel.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f0b93c0004cff49ec42f9c2a41da62543678fdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->