### PR TITLE
Revert "2.0.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0]
-
 ### Added
 
 - Added multi language support
@@ -29,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of this action ([#29](https://github.com/MetaMask/action-security-code-scanner/pull/29))
 
-[Unreleased]: https://github.com/metamask/action-security-code-scanner/compare/v2.0.0...HEAD
-[2.0.0]: https://github.com/metamask/action-security-code-scanner/compare/v1.1.0...v2.0.0
+[Unreleased]: https://github.com/metamask/action-security-code-scanner/compare/v1.1.0...HEAD
 [1.1.0]: https://github.com/metamask/action-security-code-scanner/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/metamask/action-security-code-scanner/releases/tag/v1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/action-security-code-scanner",
-  "version": "2.0.0",
+  "version": "1.2.0",
   "private": true,
   "description": "Security Code Scanner",
   "repository": {

--- a/packages/codeql-action/package.json
+++ b/packages/codeql-action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/codeql-action",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Custom CodeQL analysis action",
   "keywords": [],

--- a/packages/language-detector/package.json
+++ b/packages/language-detector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/language-detector",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "Language detection and matrix generation for code scanning",
   "type": "module",
   "main": "src/index.js",

--- a/packages/semgrep-action/package.json
+++ b/packages/semgrep-action/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metamask/semgrep-action",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "private": true,
   "description": "Semgrep-based security scanning action",
   "keywords": [


### PR DESCRIPTION
Reverts MetaMask/action-security-code-scanner#49

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts the 2.0.0 release by restoring 1.x package versions and aligning the changelog and compare links.
> 
> - **Versioning**:
>   - Restore root `package.json` to `version: 1.2.0` (from `2.0.0`).
>   - Set `packages/codeql-action`, `packages/language-detector`, and `packages/semgrep-action` to `version: 1.0.0` (from `2.0.0`).
> - **Changelog**:
>   - Remove `2.0.0` section; move its notes under `Unreleased`.
>   - Update compare links to start from `v1.1.0...HEAD` and drop `v2.0.0` references.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e4874c613d3110254029eadbf42031f7139fe39f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->