### PR TITLE
fix: Add missing unreleased reference in changelogs

### DIFF
--- a/packages/codeql-action/CHANGELOG.md
+++ b/packages/codeql-action/CHANGELOG.md
@@ -12,3 +12,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Migrated action from its separate repository to the monorepo
 - Added multi language support
 - Updated CodeQL action to v4
+
+[Unreleased]: https://github.com/metamask/action-security-code-scanner/

--- a/packages/language-detector/CHANGELOG.md
+++ b/packages/language-detector/CHANGELOG.md
@@ -10,3 +10,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added support for autodetecting languages using Github API
+
+[Unreleased]: https://github.com/metamask/action-security-code-scanner/

--- a/packages/semgrep-action/CHANGELOG.md
+++ b/packages/semgrep-action/CHANGELOG.md
@@ -10,3 +10,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Migrated action from its separate repository to the monorepo
+
+[Unreleased]: https://github.com/metamask/action-security-code-scanner/


### PR DESCRIPTION
The unreleased reference was missing from the changelog.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add missing `[Unreleased]` reference links to three package changelogs.
> 
> - **Changelogs**:
>   - Add `[Unreleased]` reference link to:
>     - `packages/codeql-action/CHANGELOG.md`
>     - `packages/language-detector/CHANGELOG.md`
>     - `packages/semgrep-action/CHANGELOG.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d685079732fc773160f66e883af4bc89ab38480. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->