### PR TITLE
fix: Use secrets for `project-metrics-token` and `slack-webhook`

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -48,16 +48,13 @@ on:
         required: false
         type: string
         default: ''
+    secrets:
       project-metrics-token:
         description: 'Analytics token to log failed builds'
         required: false
-        type: string
-        default: ''
       slack-webhook:
         description: 'Slack webhook for notifications'
         required: false
-        type: string
-        default: ''
 
 env:
   MONOREPO_PATH: .security-scanner
@@ -164,8 +161,8 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     env:
-      SLACK_WEBHOOK: ${{ inputs.slack-webhook }}
-      PROJECT_METRICS_TOKEN: ${{ inputs.project-metrics-token }}
+      SLACK_WEBHOOK: ${{ secrets.slack-webhook }}
+      PROJECT_METRICS_TOKEN: ${{ secrets.project-metrics-token }}
       REPO: ${{ inputs.repo }}
     steps:
       - name: Determine overall scan result


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the security-scan workflow to read `project-metrics-token` and `slack-webhook` from `secrets` and use them in the finalize job.
> 
> - **GitHub Actions: `security-scan.yml`**
>   - Move `project-metrics-token` and `slack-webhook` from `inputs` to `secrets` in `workflow_call`.
>   - Update `finalize` job env to use `secrets` for `PROJECT_METRICS_TOKEN` and `SLACK_WEBHOOK`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 346750edc72e2eb9f7d5e985d4cf79047446348e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->