### PR TITLE
docs: Update `codeql-action` README to use `v2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ jobs:
     uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@v2
     with:
       scanner-ref: v2
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
 ```
 
 The workflow will:

--- a/packages/codeql-action/README.md
+++ b/packages/codeql-action/README.md
@@ -42,10 +42,10 @@ name: Security Scan
 on: [push, pull_request]
 
 jobs:
-  security:
-    uses: metamask/security-codescanner-monorepo/.github/workflows/security-scan.yml@main
+  security-scan:
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@v2
     with:
-      repo: ${{ github.repository }}
+      scanner-ref: v2
     permissions:
       actions: read
       contents: read


### PR DESCRIPTION
The README in `codeql-action` was referencing the wrong repository and outdated options. I've fixed that here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refresh README examples to use the v2 reusable workflow with `scanner-ref: v2` and include the minimal GitHub permissions.
> 
> - **Docs**:
>   - **Root `README.md`**:
>     - Add minimal `permissions` block to the reusable workflow example (`actions: read`, `contents: read`, `security-events: write`).
>   - **`packages/codeql-action/README.md`**:
>     - Update reusable workflow example to `MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@v2` with `scanner-ref: v2`.
>     - Rename job to `security-scan` and include minimal `permissions` block.
>     - Remove outdated `repo` input from workflow example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aaf957e8d0a384e7e8550c940fdfce4c5ba2e90b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->