### PR TITLE
feat: Update language detector and job configurator to add Github Actions s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated language detector to add Github Actions support by default
+
 ## [2.0.1]
 
 ### Fixed

--- a/packages/language-detector/CHANGELOG.md
+++ b/packages/language-detector/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated job configurator to add Github Actions support by default
+
 ## [2.0.1]
 
 ### Fixed

--- a/packages/language-detector/src/job-configurator.js
+++ b/packages/language-detector/src/job-configurator.js
@@ -36,6 +36,7 @@ const DEFAULT_CONFIGS = {
   cpp: { language: 'cpp' },
   csharp: { language: 'csharp' },
   ruby: { language: 'ruby' },
+  actions: { language: 'actions' },
 };
 
 /**
@@ -89,8 +90,8 @@ export function createMatrix(detectedLanguages, languagesConfig = []) {
   console.error('Auto-detected languages:', detectedLanguages);
   console.error('Provided custom configs:', languagesConfig);
 
-  // Remove duplicates from detected languages
-  const uniqueLanguages = [...new Set(detectedLanguages)];
+  // Remove duplicates from detected languages and always add 'actions'
+  const uniqueLanguages = [...new Set([...detectedLanguages, 'actions'])];
 
   for (const lang of uniqueLanguages) {
     // Check for custom config that matches this language


### PR DESCRIPTION
Add github actions scanning by default

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds default support for scanning GitHub Actions by including `actions` in the matrix and configuration; updates changelogs.
> 
> - **Language Detector** (`packages/language-detector/src/job-configurator.js`):
>   - Add default config for `actions` in `DEFAULT_CONFIGS`.
>   - Always include `actions` in the generated matrix (with de-duplication).
> - **Changelogs**:
>   - Update `CHANGELOG.md` and `packages/language-detector/CHANGELOG.md` to note default GitHub Actions support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f536921e82e1d9d3ef92881bfacbdd7ea88b246. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->