### PR TITLE
chore: Update Slack GitHub Action versionto switch to node 24 action

### DIFF
--- a/.github/workflows/onboard-new-repo.yml
+++ b/.github/workflows/onboard-new-repo.yml
@@ -275,7 +275,7 @@ jobs:
 
       - name: Post to Slack channel on failure
         if: ${{ failure() && env.SLACK_WEBHOOK_URL != '' }}
-        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
         with:
           payload: |
             {

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,7 +47,7 @@ jobs:
           echo "FINAL_TEXT=$FINAL_TEXT" >> "$GITHUB_OUTPUT"
       - name: Post to a Slack channel
         if: inputs.slack-subteam != ''
-        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
         with:
           payload: |
             {

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Post to Slack channel
         if: ${{ steps.scan-result.outputs.result == 'failure' && env.SLACK_WEBHOOK != '' }}
-        uses: slackapi/slack-github-action@007b2c3c751a190b6f0f040e47ed024deaa72844
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
         with:
           payload: |
             {


### PR DESCRIPTION
bumping slack action to updated node24 version 
their fix PR - https://github.com/slackapi/slack-github-action/pull/567
version already tesed and working in mobile repo - https://github.com/MetaMask/metamask-mobile/blob/4f97a52987c875d386ac2a8ec919d714cced6a35/.github/workflows/run-performance-e2e.yml#L474C44-L474C84

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk version bump limited to Slack notification steps in CI workflows; main risk is Slack posting behavior changing or failing in these jobs.
> 
> **Overview**
> Upgrades the pinned `slackapi/slack-github-action` SHA in the workflows that post Slack notifications (`onboard-new-repo.yml`, `publish-release.yml`, and `security-scan.yml`). No workflow logic changes beyond using the newer Slack action version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a9d7e9107bc43646e1ce91085afa35994705e7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->