### PR TITLE
feat: Add static analysis step with zizmor to security scan workflow

### DIFF
--- a/.github/templates/security-code-scanner.yml
+++ b/.github/templates/security-code-scanner.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   security-scan:
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@v2
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@1cd598629833fa9fc1694f03abfce8d21b72eb5d # v2
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@89c66bb715514a0abd2e6bbfb3cae312b0100913 # v3.2.0
         with:
           is-high-risk-environment: false
           cache-node-modules: true
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v1
+        uses: MetaMask/action-checkout-and-setup@89c66bb715514a0abd2e6bbfb3cae312b0100913 # v3.2.0
         with:
           is-high-risk-environment: false
           cache-node-modules: true

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           # This is to guarantee that the most recent tag is fetched.
           # This can be configured to a more reasonable value by consumers.
@@ -30,10 +30,10 @@ jobs:
           # branch for all git operations and the release PR.
           ref: ${{ github.event.inputs.base-branch }}
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
-      - uses: MetaMask/action-create-release-pr@v4
+      - uses: MetaMask/action-create-release-pr@4b3b9f5e764afa2e028c1759fcc9891e591d6782 # v5.0.0
         with:
           release-type: ${{ github.event.inputs.release-type }}
           release-version: ${{ github.event.inputs.release-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check workflows
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - name: Download actionlint
         id: download-actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/7fdc9630cc360ea1a469eed64ac6d78caeda1234/scripts/download-actionlint.bash) 1.7.7
@@ -70,7 +70,7 @@ jobs:
       IS_RELEASE: ${{ steps.is-release.outputs.IS_RELEASE }}
     steps:
       - id: is-release
-        uses: MetaMask/action-is-release@v2
+        uses: MetaMask/action-is-release@61ff8882da996cb68cdbc8583dc53956a1ffdd8b # v2.2.0
 
   publish-release:
     needs: is-release

--- a/.github/workflows/onboard-new-repo.yml
+++ b/.github/workflows/onboard-new-repo.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout scanner action repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           path: scanner-repo
 
@@ -73,7 +73,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app_token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.ONBOARDING_APP_ID }}
           private-key: ${{ secrets.ONBOARDING_APP_PRIVATE_KEY }}
@@ -154,7 +154,7 @@ jobs:
 
       - name: Checkout target repository
         if: steps.check_opt_out.outputs.opted_out != 'true' && steps.check_empty.outputs.is_empty == 'false'
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           repository: ${{ steps.target.outputs.repository }}
           token: ${{ steps.app_token.outputs.token }}
@@ -275,7 +275,7 @@ jobs:
 
       - name: Post to Slack channel on failure
         if: ${{ failure() && env.SLACK_WEBHOOK_URL != '' }}
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           payload: |
             {

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,7 +24,7 @@ jobs:
     name: Announce release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       - id: name-hash
         name: Get Slack name and hash
         shell: bash
@@ -47,7 +47,7 @@ jobs:
           echo "FINAL_TEXT=$FINAL_TEXT" >> "$GITHUB_OUTPUT"
       - name: Post to a Slack channel
         if: inputs.slack-subteam != ''
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           payload: |
             {
@@ -69,14 +69,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           # This is to guarantee that the most recent tag is fetched, which we
           # need for updating the shorthand major version tag.
           fetch-depth: 0
           ref: ${{ github.sha }}
       - name: Publish release
-        uses: MetaMask/action-publish-release@v3
+        uses: MetaMask/action-publish-release@b842808ef45c9e3b085060b94b1d4a1fac00aa81 # v3.2.2
         id: publish-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -68,14 +68,14 @@ jobs:
       matrix: ${{ steps.detect-languages.outputs.matrix }}
     steps:
       - name: Checkout monorepo (for local actions)
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           repository: MetaMask/action-security-code-scanner
           ref: ${{ inputs.scanner-ref }}
           path: ${{ env.MONOREPO_PATH }}
 
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           repository: ${{ inputs.repo }}
           path: ${{ inputs.repo }}
@@ -102,14 +102,14 @@ jobs:
       security-events: write
     steps:
       - name: Checkout monorepo (for local actions)
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           repository: MetaMask/action-security-code-scanner
           ref: ${{ inputs.scanner-ref }}
           path: ${{ env.MONOREPO_PATH }}
 
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           repository: ${{ inputs.repo }}
           path: ${{ inputs.repo }}
@@ -137,14 +137,14 @@ jobs:
       security-events: write
     steps:
       - name: Checkout monorepo (for local actions)
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           repository: MetaMask/action-security-code-scanner
           ref: ${{ inputs.scanner-ref }}
           path: ${{ env.MONOREPO_PATH }}
 
       - name: Checkout target repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           repository: ${{ inputs.repo }}
           path: ${{ inputs.repo }}
@@ -168,7 +168,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout target repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           repository: ${{ inputs.repo }}
           path: ${{ inputs.repo }}
@@ -211,7 +211,7 @@ jobs:
 
       - name: Post to Slack channel
         if: ${{ steps.scan-result.outputs.result == 'failure' && env.SLACK_WEBHOOK != '' }}
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           payload: |
             {

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -154,10 +154,39 @@ jobs:
         with:
           paths_ignored: ${{ inputs.paths-ignored }}
 
+  # Static analysis of GitHub Actions workflows using zizmor
+  # (https://docs.zizmor.sh/). Surfaces workflow-level patterns that enable
+  # supply-chain attacks: `pull_request_target` "Pwn Request", template
+  # injection, excessive permissions, OIDC token exposure, cache poisoning,
+  # and unpinned uses.
+  zizmor:
+    name: zizmor
+    runs-on: ubuntu-latest
+    needs: setup
+
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout target repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ inputs.repo }}
+          path: ${{ inputs.repo }}
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          inputs: ${{ inputs.repo }}
+          persona: pedantic
+          min-severity: medium
+          advanced-security: 'false'
+          annotations: 'true'
+
   # Collect results and handle notifications
   finalize:
     name: Finalize scans and notify
-    needs: [codeql-analysis, semgrep-analysis]
+    needs: [codeql-analysis, semgrep-analysis, zizmor]
     if: always()
     runs-on: ubuntu-latest
     env:
@@ -170,8 +199,9 @@ jobs:
         env:
           CODEQL_RESULT: ${{ needs.codeql-analysis.result }}
           SEMGREP_RESULT: ${{ needs.semgrep-analysis.result }}
+          ZIZMOR_RESULT: ${{ needs.zizmor.result }}
         run: |
-          if [[ "$CODEQL_RESULT" == "failure" || "$SEMGREP_RESULT" == "failure" ]]; then
+          if [[ "$CODEQL_RESULT" == "failure" || "$SEMGREP_RESULT" == "failure" || "$ZIZMOR_RESULT" == "failure" ]]; then
             echo "result=failure" >> "$GITHUB_OUTPUT"
             echo "SCAN_RESULT=failure" >> "$GITHUB_ENV"
           else

--- a/.github/workflows/test-semgrep.yml
+++ b/.github/workflows/test-semgrep.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       - name: Install Semgrep
         run: |

--- a/.github/workflows/validate-conventional-commits.yml
+++ b/.github/workflows/validate-conventional-commits.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ !startsWith(github.head_ref , 'release/') }}
     steps:
-      # this is a hash for amannn/action-semantic-pull-request@v5.4.0
-      - uses: amannn/action-semantic-pull-request@e9fabac35e210fea40ca5b14c0da95a099eff26f
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/examples/security-code-scanner.yml
+++ b/examples/security-code-scanner.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   security-scan:
-    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@v2
+    uses: MetaMask/action-security-code-scanner/.github/workflows/security-scan.yml@1cd598629833fa9fc1694f03abfce8d21b72eb5d # v2
     permissions:
       actions: read
       contents: read

--- a/packages/codeql-action/action.yaml
+++ b/packages/codeql-action/action.yaml
@@ -107,14 +107,14 @@ runs:
 
     - name: Checkout Custom Query Repository
       id: checkout-custom-query
-      uses: actions/checkout@v4
+      uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
       with:
         repository: metamask/CodeQL-Queries
         ref: main
         path: ${{ github.workspace }}/custom-queries
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
       with:
         config-file: ${{ github.workspace }}/codeql-config-generated.yml
         languages: ${{ inputs.language }}
@@ -123,7 +123,7 @@ runs:
 
     - name: Set up JDK for Java/Kotlin
       if: ${{ (inputs.language == 'java-kotlin' || inputs.language == 'java') && steps.generate-config.outputs.version != '' }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         java-version: ${{ steps.generate-config.outputs.version }}
         distribution: ${{ steps.generate-config.outputs.distribution || 'temurin' }}
@@ -142,13 +142,13 @@ runs:
 
     - name: Run CodeQL Analysis
       id: codeql-analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
       with:
         upload: false
         checkout_path: ${{ github.workspace }}/${{ inputs.repo }}
 
     - name: Upload SARIF file
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
       with:
         sarif_file: ${{ steps.codeql-analysis.outputs.sarif-output }}
         category: codeql-${{ inputs.language }}

--- a/packages/language-detector/action.yml
+++ b/packages/language-detector/action.yml
@@ -37,7 +37,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: '20'
 

--- a/packages/semgrep-action/action.yml
+++ b/packages/semgrep-action/action.yml
@@ -31,7 +31,7 @@ runs:
       continue-on-error: true
 
     - name: Upload Semgrep Results to GitHub
-      uses: github/codeql-action/upload-sarif@v4
+      uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
       with:
         sarif_file: semgrep-results.sarif
         checkout_path: ${{ github.workspace }}

--- a/packages/semgrep-action/rules/test/generic/npx-usage/npx-usage-yml.test.yml
+++ b/packages/semgrep-action/rules/test/generic/npx-usage/npx-usage-yml.test.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
 
       # Test basic npx usage in GitHub Actions - should be flagged
       - name: Run tests

--- a/packages/semgrep-action/rules/test/github-actions/publish-actions-cache-used.test.yaml
+++ b/packages/semgrep-action/rules/test/github-actions/publish-actions-cache-used.test.yaml
@@ -14,29 +14,29 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           ref: ${{ github.sha }}
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
       - name: Install Yarn
         run: corepack enable
       - name: Restore Yarn cache
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
           # ruleid: publish-actions-cache-used
           cache: yarn
       # ruleid: publish-actions-cache-used
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ./packages/**/dist
             ./node_modules/.yarn-state.yml
           key: ${{ github.sha }}
-      - uses: MetaMask/action-publish-release@v3
+      - uses: MetaMask/action-publish-release@b842808ef45c9e3b085060b94b1d4a1fac00aa81 # v3.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn --immutable
@@ -46,17 +46,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-release
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           ref: ${{ github.sha }}
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
       - name: Install Yarn
         run: corepack enable
       # ruleid: publish-actions-cache-used
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ./packages/**/dist
@@ -65,7 +65,7 @@ jobs:
           fail-on-cache-miss: true
       - name: Dry Run Publish
         # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@01b1c42700c693464b19c6a2e42bf771698763b3 # v6.2.1
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
@@ -77,17 +77,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish-npm-dry-run
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9f698171ed81b15d1823a05fc7211befd50c8ae0 # v6.0.3
         with:
           ref: ${{ github.sha }}
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.nvmrc'
       - name: Install Yarn
         run: corepack enable
       # ruleid: publish-actions-cache-used
-      - uses: actions/cache@v4
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ./packages/**/dist
@@ -95,7 +95,7 @@ jobs:
           key: ${{ github.sha }}
           fail-on-cache-miss: true
       - name: Publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@01b1c42700c693464b19c6a2e42bf771698763b3 # v6.2.1
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
         env:


### PR DESCRIPTION
Integrate zizmor for static analysis of GitHub Actions workflows, enhancing security by identifying potential supply-chain attack patterns. Update finalization step to include zizmor results in failure checks.

example run https://github.com/witmicko/metamask-extension/actions/runs/27136161666

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect org-wide security CI gates and may fail scans on medium+ zizmor findings; widespread action version bumps could alter checkout/setup behavior in release and onboarding workflows.
> 
> **Overview**
> Adds **zizmor** static analysis to the reusable security scan workflow so target repos’ GitHub Actions workflows are checked for supply-chain risks (unpinned `uses`, dangerous `pull_request_target` patterns, permissions, etc.). The new job checks out the scanned repo with `persist-credentials: false`, runs `zizmorcore/zizmor-action` in **pedantic** mode with **medium+** severity and PR annotations, and **finalize** now treats a zizmor failure like CodeQL/Semgrep failures for Slack and job failure.
> 
> Across CI, templates, examples, composite actions, and Semgrep rule fixtures, **`uses:` references are pinned to full commit SHAs** (with version comments) instead of floating `@v*` tags—including bumps such as `actions/checkout` v6, `setup-node` v6, MetaMask actions, Slack, semantic PR title, and the scanner workflow ref in consumer templates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16fe0543dae7c235c4c2b2c4ac065be2037ae92b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->