### PR TITLE
fix: resource not accessible by integration

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -165,6 +165,7 @@ jobs:
     needs: setup
 
     permissions:
+      actions: read
       contents: read
       security-events: write
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Add `actions: read` permission to the zizmor job to fix "resource not accessible by integration" errors
+- Add `actions: read` permission to the zizmor job to fix "resource not accessible by integration" errors in private repositories
 
 ## [2.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `actions: read` permission to the zizmor job to fix "resource not accessible by integration" errors
+
 ## [2.1.0]
 
 ### Added


### PR DESCRIPTION
## Summary

Adds `actions: read` permission to the `zizmor` job in the security scan workflow to fix "resource not accessible by integration" errors.

## Changes

- Grant `actions: read` on the `zizmor` job alongside existing `contents: read` and `security-events: write` permissions

## Why

The zizmor job analyzes GitHub Actions workflows and needs read access to Actions resources. Without this permission, the job fails when running via the GitHub App integration.

## Test plan

- [x] Run the security scan workflow on a test repo and confirm the zizmor job completes without permission errors
- [x] Confirm zizmor SARIF is still uploaded to code scanning

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single read-only permission on one CI job; aligns zizmor with existing scan jobs and does not broaden write or deployment access.
> 
> **Overview**
> Fixes the **zizmor** job in the security scan workflow failing with **"resource not accessible by integration"** when the scan runs via the GitHub App (notably on private repos).
> 
> Adds **`actions: read`** to that job’s permissions so it matches **CodeQL** and **Semgrep**, which already use the same trio (`actions: read`, `contents: read`, `security-events: write`). zizmor needs Actions API access to analyze workflow files.
> 
> **CHANGELOG** records the fix under Unreleased → Fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f7a73b0981d752a922d25d5c41fe0e0f41e6fd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->