### PR TITLE
Fix: Update onboarding workflow to grant write permission for workflows

### DIFF
--- a/.github/workflows/onboard-new-repo.yml
+++ b/.github/workflows/onboard-new-repo.yml
@@ -84,6 +84,7 @@ jobs:
           permission-metadata: read
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - name: Detect default branch
         id: detect_branch


### PR DESCRIPTION
- Added 'permission-workflows: write' to enhance access control in the onboarding process and fix current run failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single scope addition on an internal onboarding workflow; no change to runtime scanner behavior or application code.
> 
> **Overview**
> The **onboard new repository** workflow now requests **`permission-workflows: write`** when minting the onboarding GitHub App token, alongside existing contents and pull-request write scopes.
> 
> That lets the bot push branches that add or update **`.github/workflows/`** files (e.g. the SAST scanner workflow) without failing on GitHub’s workflow-file protection, which was blocking successful onboarding runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41e1cc1d51fa04dfeab577a4069022035ccc526e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->