### PR TITLE
fix SLACK_WEBHOOK_TYPE to lowercase in workflow files

### DIFF
--- a/.github/workflows/onboard-new-repo.yml
+++ b/.github/workflows/onboard-new-repo.yml
@@ -292,4 +292,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_WEBHOOK_TYPE: incoming-webhook

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -67,7 +67,7 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_WEBHOOK_TYPE: incoming-webhook
         continue-on-error: true
 
   publish-release:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -230,7 +230,7 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_WEBHOOK_TYPE: incoming-webhook
 
       - name: Log metrics
         if: ${{ env.PROJECT_METRICS_TOKEN != '' }}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Cosmetic env value fix for Slack webhook configuration; no auth, secrets, or scan logic changes.
> 
> **Overview**
> Updates **`SLACK_WEBHOOK_TYPE`** from `INCOMING_WEBHOOK` to **`incoming-webhook`** everywhere the pinned **`slackapi/slack-github-action`** step posts Slack notifications.
> 
> The change applies to failure alerts in **onboard-new-repo**, release announcements in **publish-release**, and security scan failures in **security-scan**. Payloads, webhooks, and action versions are unchanged—only the webhook type env value is normalized to lowercase.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e520b227955ba2ccb9821d42949f19cd5e702b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->