### PR TITLE
Fix: slack action

### DIFF
--- a/.github/package.json
+++ b/.github/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@metamask/action-code-scanner-github",
+  "version": "2.1.0",
+  "private": true,
+  "description": "GitHub Actions workflows for the security code scanner",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/action-security-code-scanner.git"
+  },
+  "license": "ISC",
+  "author": "metamask"
+}

--- a/.github/workflows/onboard-new-repo.yml
+++ b/.github/workflows/onboard-new-repo.yml
@@ -84,6 +84,7 @@ jobs:
           permission-metadata: read
           permission-contents: write
           permission-pull-requests: write
+          permission-workflows: write
 
       - name: Detect default branch
         id: detect_branch
@@ -285,10 +286,11 @@ jobs:
         if: ${{ failure() && env.SLACK_WEBHOOK_URL != '' }}
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "Onboarding failed for ${{ steps.target.outputs.repository }} - Run: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          

--- a/.github/workflows/onboard-new-repo.yml
+++ b/.github/workflows/onboard-new-repo.yml
@@ -293,4 +293,3 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.APPSEC_BOT_SLACK_WEBHOOK }}
-          

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -67,7 +67,7 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_WEBHOOK_TYPE: incoming-webhook
         continue-on-error: true
 
   publish-release:

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -223,14 +223,14 @@ jobs:
         if: ${{ steps.scan-result.outputs.result == 'failure' && env.SLACK_WEBHOOK != '' }}
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "Security scan failed for ${{ env.REPO }} - Run: https://github.com/${{ env.REPO }}/actions/runs/${{ github.run_id }}",
               "channel": "#security-notifications"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_WEBHOOK_URL: ${{ env.APPSEC_BOT_SLACK_WEBHOOK }}
 
       - name: Log metrics
         if: ${{ env.PROJECT_METRICS_TOKEN != '' }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -230,7 +230,7 @@ jobs:
               "channel": "#security-notifications"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ env.APPSEC_BOT_SLACK_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK }}
 
       - name: Log metrics
         if: ${{ env.PROJECT_METRICS_TOKEN != '' }}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 This monorepo provides a reusable security scanning workflow with automatic language detection and parallel execution:
 
 - **`.github/workflows/security-scan.yml`** - Main reusable workflow (orchestrator)
+- **`.github/`** - Workspace package for workflow versioning (`@metamask/action-code-scanner-github`)
 - **`packages/language-detector/`** - Detects languages and creates scan matrix
 - **`packages/codeql-action/`** - Custom CodeQL analysis with repo-specific configs
 - **`packages/semgrep-action/`** - Semgrep pattern-based scanner
@@ -110,8 +111,10 @@ jobs:
 
 ```
 security-scanner-monorepo/
-├── .github/workflows/
-│   └── security-scan.yml        # Main reusable workflow
+├── .github/                     # Workflow workspace package
+│   ├── package.json
+│   └── workflows/
+│       └── security-scan.yml    # Main reusable workflow
 ├── packages/
 │   ├── language-detector/       # Language detection & matrix creation
 │   ├── codeql-action/          # CodeQL scanner

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "author": "metamask",
   "type": "module",
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    ".github/"
   ],
   "scripts": {
     "build": "yarn workspaces foreach -A run build",

--- a/shared/scripts/check-packages.js
+++ b/shared/scripts/check-packages.js
@@ -17,7 +17,11 @@ const workspacePackages = [
   })),
 ];
 
-function checkPackage({ name: packageName, path: packagePath, requiresAction }) {
+function checkPackage({
+  name: packageName,
+  path: packagePath,
+  requiresAction,
+}) {
   const packageJsonPath = join(packagePath, 'package.json');
 
   console.log(`\n🔍 Checking package: ${packageName}`);

--- a/shared/scripts/check-packages.js
+++ b/shared/scripts/check-packages.js
@@ -8,10 +8,16 @@ import { execSync } from 'child_process';
 import { readFileSync, readdirSync, accessSync, constants } from 'fs';
 import { join } from 'path';
 
-const packagesDir = 'packages';
+const workspacePackages = [
+  { name: '.github', path: '.github', requiresAction: false },
+  ...readdirSync('packages').map((packageName) => ({
+    name: packageName,
+    path: join('packages', packageName),
+    requiresAction: true,
+  })),
+];
 
-function checkPackage(packageName) {
-  const packagePath = join(packagesDir, packageName);
+function checkPackage({ name: packageName, path: packagePath, requiresAction }) {
   const packageJsonPath = join(packagePath, 'package.json');
 
   console.log(`\n🔍 Checking package: ${packageName}`);
@@ -34,6 +40,11 @@ function checkPackage(packageName) {
       console.log(`  ⚠️  Package is not marked as private`);
     } else {
       console.log(`  ✅ Package is correctly marked as private`);
+    }
+
+    if (!requiresAction) {
+      console.log(`  ℹ️  Workflow package (no action.yml required)`);
+      return;
     }
 
     // Check if action.yml or action.yaml exists
@@ -86,8 +97,7 @@ function main() {
   console.log('🚀 Checking all packages...');
 
   try {
-    const packages = readdirSync(packagesDir);
-    packages.forEach(checkPackage);
+    workspacePackages.forEach(checkPackage);
 
     console.log('\n✨ Package check complete!');
   } catch (error) {

--- a/shared/scripts/clean-all.js
+++ b/shared/scripts/clean-all.js
@@ -52,16 +52,17 @@ function main() {
   // Clean root directory
   cleanDirectory('.', artifactPaths);
 
-  // Clean packages
+  // Clean workspace packages
+  const workspacePaths = ['.github', ...execSync('ls packages/', { stdio: 'pipe' })
+    .toString()
+    .trim()
+    .split('\n')
+    .map((packageName) => join('packages', packageName))];
+
   try {
-    execSync('ls packages/', { stdio: 'pipe' })
-      .toString()
-      .trim()
-      .split('\n')
-      .forEach((packageName) => {
-        const packagePath = join('packages', packageName);
-        cleanDirectory(packagePath, artifactPaths);
-      });
+    workspacePaths.forEach((packagePath) => {
+      cleanDirectory(packagePath, artifactPaths);
+    });
   } catch (error) {
     console.error('❌ Error cleaning packages:', error.message);
   }

--- a/shared/scripts/clean-all.js
+++ b/shared/scripts/clean-all.js
@@ -53,11 +53,14 @@ function main() {
   cleanDirectory('.', artifactPaths);
 
   // Clean workspace packages
-  const workspacePaths = ['.github', ...execSync('ls packages/', { stdio: 'pipe' })
-    .toString()
-    .trim()
-    .split('\n')
-    .map((packageName) => join('packages', packageName))];
+  const workspacePaths = [
+    '.github',
+    ...execSync('ls packages/', { stdio: 'pipe' })
+      .toString()
+      .trim()
+      .split('\n')
+      .map((packageName) => join('packages', packageName)),
+  ];
 
   try {
     workspacePaths.forEach((packagePath) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,6 +796,12 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/action-code-scanner-github@workspace:.github":
+  version: 0.0.0-use.local
+  resolution: "@metamask/action-code-scanner-github@workspace:.github"
+  languageName: unknown
+  linkType: soft
+
 "@metamask/action-security-code-scanner@workspace:.":
   version: 0.0.0-use.local
   resolution: "@metamask/action-security-code-scanner@workspace:."


### PR DESCRIPTION
- fixed slack action
- updated actions script to include .github dir to be included in packages for release

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI notification wiring and monorepo metadata/scripts only; no auth, scan logic, or runtime behavior changes.
> 
> **Overview**
> **Slack notifications** in `security-scan.yml` and `onboard-new-repo.yml` now pass `webhook-type: incoming-webhook` under the `slackapi/slack-github-action` `with:` inputs instead of `SLACK_WEBHOOK_TYPE` in `env`, matching the action’s expected configuration.
> 
> **Monorepo packaging** treats `.github` as a first-class Yarn workspace via new `@metamask/action-code-scanner-github` (`package.json` under `.github/`, root `workspaces`, and `yarn.lock`). `check-packages.js` validates that workspace without requiring `action.yml`; `clean-all.js` cleans `.github` alongside `packages/*`. README architecture/package tree docs reflect the workflow workspace package for release versioning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9b4f4f244c410ea2fdb90b91099013114dd05d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->