### PR TITLE
fix: add missing changelog

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add `.github/` as a workspace package for workflow versioning
+
+### Changed
+
+- Use token exchange for release publishing instead of `GITHUB_TOKEN`
+- Grant `workflows: write` permission in onboarding workflow
+
+### Fixed
+
+- Fix Slack webhook configuration to use `webhook-type` input instead of deprecated `SLACK_WEBHOOK_TYPE` env var
+- Add `actions: read` permission to zizmor job to fix "resource not accessible by integration" errors in private repositories
+
+## [2.1.0]
+
+### Added
+
+- Add zizmor static analysis of GitHub Actions workflows
+
+### Fixed
+
+- Addressed zizmor findings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `.github/` as a workspace package for workflow versioning
+
+### Changed
+
+- Use token exchange for release publishing instead of `GITHUB_TOKEN`
+- Grant `workflows: write` permission in onboarding workflow
+
 ### Fixed
 
+- Fix Slack webhook configuration to use `webhook-type` input instead of deprecated `SLACK_WEBHOOK_TYPE` env var
 - Add `actions: read` permission to the zizmor job to fix "resource not accessible by integration" errors in private repositories
 
 ## [2.1.0]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changelog updates with no runtime or application code changes.
> 
> **Overview**
> Adds a **`.github/CHANGELOG.md`** for the workflow package and updates the root **`CHANGELOG.md`** **[Unreleased]** section so recent CI changes are documented.
> 
> **Added** documents treating **`.github/`** as a workspace package for workflow versioning. **Changed** covers release publishing via **token exchange** (replacing **`GITHUB_TOKEN`**) and granting **`workflows: write`** in the onboarding workflow. **Fixed** notes the Slack action **`webhook-type`** input (instead of **`SLACK_WEBHOOK_TYPE`**) and **`actions: read`** on the zizmor job for private-repo integration errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9255e874af25abad9d5b835abe881fdfb2b34800. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->