### PR TITLE
fix: fix changelog

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -30,3 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Addressed zizmor findings
+
+[Unreleased]: https://github.com/MetaMask/action-security-code-scanner/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/MetaMask/action-security-code-scanner/releases/tag/v2.1.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only changelog link fixes with no runtime or security impact.
> 
> **Overview**
> Adds the **Keep a Changelog** footer links that were missing after the `[2.1.0]` section: `[Unreleased]` now points at `v2.1.0...HEAD`, and `[2.1.0]` points at the release tag.
> 
> No functional or workflow behavior changes—documentation only in `.github/CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2253c7c4e318dc5dd4c78a477ab8718ce4427413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->