### PR TITLE
chore: Add `MetaMask/core-platform` as co-owner to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @MetaMask/application-security
+* @MetaMask/application-security @MetaMask/core-platform


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Repository governance only; no application code or runtime behavior changes.
> 
> **Overview**
> Adds **`@MetaMask/core-platform`** as a second default owner on the catch-all `*` rule in **`.github/CODEOWNERS`**, alongside **`@MetaMask/application-security`**.
> 
> Pull requests that previously auto-requested only application-security will now also request review from core-platform for repo-wide changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8049646c0a956a0a520eb4c8746b4ad56a35b4e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->