### PR TITLE
update announce release slack step

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -60,14 +60,13 @@ jobs:
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook-type: incoming-webhook
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           payload: |
             {
               "text": "${{ steps.final-text.outputs.FINAL_TEXT }}",
               "icon_url": "${{ inputs.slack-icon-url }}",
               "username": "${{ inputs.slack-username }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         continue-on-error: true
 
   publish-release:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -59,6 +59,7 @@ jobs:
         if: inputs.slack-subteam != ''
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "${{ steps.final-text.outputs.FINAL_TEXT }}",
@@ -67,7 +68,6 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: incoming-webhook
         continue-on-error: true
 
   publish-release:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change to how the Slack webhook is passed; no application or security logic is affected.
> 
> **Overview**
> Updates the **announce-release** job in `publish-release.yml` so `slackapi/slack-github-action` v3 gets the incoming webhook via **`with`** instead of environment variables.
> 
> The step now sets `webhook-type: incoming-webhook` and `webhook: ${{ secrets.SLACK_WEBHOOK_URL }}`, and drops the old `SLACK_WEBHOOK_URL` / `SLACK_WEBHOOK_TYPE` **env** block. Release Slack message content and `continue-on-error` behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48a8035bd3362dbc5ab97fc8854444834e97a776. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->